### PR TITLE
Fix goconst linting errors

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -45,6 +45,10 @@ const (
 	pluginTimeoutFlagHelp string = "Timeout value in seconds before plugin execution is abandoned and an error returned."
 )
 
+// shorthandFlagSuffix is appended to short flag help text to emphasize that
+// the flag is a shorthand version of a longer flag.
+const shorthandFlagSuffix = " (shorthand)"
+
 // Flag names for consistent references. Exported so that they're available
 // from tests.
 const (

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -36,7 +36,7 @@ func (c *Config) handleFlagsConfig(appType AppType) error {
 	}
 
 	// shared flags
-	c.flagSet.BoolVar(&c.ShowHelp, HelpFlagShort, defaultHelp, helpFlagHelp+" (shorthand)")
+	c.flagSet.BoolVar(&c.ShowHelp, HelpFlagShort, defaultHelp, helpFlagHelp+shorthandFlagSuffix)
 	c.flagSet.BoolVar(&c.ShowHelp, HelpFlagLong, defaultHelp, helpFlagHelp)
 
 	c.flagSet.BoolVar(&c.ShowVersion, VersionFlagLong, defaultDisplayVersionAndExit, versionFlagHelp)
@@ -45,7 +45,7 @@ func (c *Config) handleFlagsConfig(appType AppType) error {
 		&c.LoggingLevel,
 		LogLevelFlagShort,
 		defaultLogLevel,
-		supportedValuesFlagHelpText(logLevelFlagHelp, supportedLogLevels())+" (shorthand)",
+		supportedValuesFlagHelpText(logLevelFlagHelp, supportedLogLevels())+shorthandFlagSuffix,
 	)
 	c.flagSet.StringVar(
 		&c.LoggingLevel,
@@ -74,7 +74,7 @@ func (c *Config) handleFlagsConfig(appType AppType) error {
 
 	switch {
 	case appType.Inspector:
-		c.flagSet.IntVar(&c.timeout, TimeoutFlagShort, defaultCLIAppTimeout, cliAppTimeoutFlagHelp+" (shorthand)")
+		c.flagSet.IntVar(&c.timeout, TimeoutFlagShort, defaultCLIAppTimeout, cliAppTimeoutFlagHelp+shorthandFlagSuffix)
 		c.flagSet.IntVar(&c.timeout, TimeoutFlagLong, defaultCLIAppTimeout, cliAppTimeoutFlagHelp)
 
 		c.flagSet.StringVar(
@@ -86,7 +86,7 @@ func (c *Config) handleFlagsConfig(appType AppType) error {
 
 	case appType.Plugin:
 		c.flagSet.BoolVar(&c.ShowVerbose, VerboseFlagLong, defaultVerbose, verboseFlagHelp)
-		c.flagSet.IntVar(&c.timeout, TimeoutFlagShort, defaultPluginTimeout, pluginTimeoutFlagHelp+" (shorthand)")
+		c.flagSet.IntVar(&c.timeout, TimeoutFlagShort, defaultPluginTimeout, pluginTimeoutFlagHelp+shorthandFlagSuffix)
 		c.flagSet.IntVar(&c.timeout, TimeoutFlagLong, defaultPluginTimeout, pluginTimeoutFlagHelp)
 
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -72,8 +72,7 @@ func (c Config) validate(appType AppType) error {
 
 	case !textutils.InList(c.NetworkType, supportedNetworkTypes(), true):
 		return fmt.Errorf(
-			"%w: invalid network type;"+
-				" got %v, expected one of %v",
+			"%w: invalid network type; got %v, expected one of %v",
 			ErrUnsupportedOption,
 			c.NetworkType,
 			supportedNetworkTypes(),
@@ -81,8 +80,7 @@ func (c Config) validate(appType AppType) error {
 
 	case !textutils.InList(c.LoggingLevel, supportedLogLevels(), true):
 		return fmt.Errorf(
-			"%w: invalid logging level;"+
-				" got %v, expected one of %v",
+			"%w: invalid logging level; got %v, expected one of %v",
 			ErrUnsupportedOption,
 			c.LoggingLevel,
 			supportedLogLevels(),
@@ -95,8 +93,7 @@ func (c Config) validate(appType AppType) error {
 		supportedFormats := supportedInspectorOutputFormats()
 		if !textutils.InList(c.InspectorOutputFormat, supportedFormats, true) {
 			return fmt.Errorf(
-				"%w: invalid output format;"+
-					" got %v, expected one of %v",
+				"%w: invalid output format; got %v, expected one of %v",
 				ErrUnsupportedOption,
 				c.InspectorOutputFormat,
 				supportedFormats,


### PR DESCRIPTION
- collapse split format strings to combine text and remove confirmed duplication
- fix goconst linting error for shorthand suffix by creating shared constant