### PR TITLE
Fix unused-param revive linting error

### DIFF
--- a/internal/netutils/connect.go
+++ b/internal/netutils/connect.go
@@ -31,7 +31,8 @@ func DialerWithContext(networkType string, logger zerolog.Logger) HTTPTransportD
 	return func(ctx context.Context, network string, address string) (net.Conn, error) {
 		logger = logger.With().
 			Str("address", address).
-			Str("net_type", networkType).
+			Str("net_type_original", network).
+			Str("net_type_overridden", networkType).
 			Logger()
 
 		logger.Debug().Msg("resolving hostname")


### PR DESCRIPTION
Emit the original `network` value used by calls to the Dialer alongside the user specified value.