### PR TITLE
Remove references to SSH server

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,14 +75,15 @@ type Config struct {
 	InspectorOutputFormat string
 
 	// NetworkType indicates whether an attempt should be made to connect to
-	// only IPv4, only IPv6 or SSH servers listening on either of IPv4 or IPv6
-	// addresses ("auto").
+	// only IPv4, only IPv6 or Red Hat Satellite API endpoints listening on
+	// either of IPv4 or IPv6 addresses ("auto").
 	NetworkType string
 
-	// Server is the SSH server FQDN or IP Address.
+	// Server is the Red Hat Satellite API endpoint FQDN or IP Address.
 	Server string
 
-	// Username is the valid user for the given SSH server.
+	// Username is the valid user for the given Red Hat Satellite API
+	// endpoint.
 	Username string
 
 	// Password is the valid password for the specified user.
@@ -92,11 +93,12 @@ type Config struct {
 	// certificate chain used by the Red Hat Satellite server.
 	CACertificate string
 
-	// TCPPort is the port used by the SSH service.
+	// TCPPort is the port used by the Red Hat Satellite API endpoint.
 	TCPPort int
 
 	// timeout is the number of seconds allowed before the connection attempt
-	// to the SSH service is abandoned and an error returned.
+	// to the Red Hat Satellite API endpoint is abandoned and an error
+	// returned.
 	timeout int
 
 	// ReadLimit is a limit in bytes set to help prevent abuse when reading

--- a/internal/netutils/connect.go
+++ b/internal/netutils/connect.go
@@ -139,12 +139,6 @@ func openConnection(ctx context.Context, addrs []string, port string, netType st
 		// Attempt to connect to the given IP Address.
 		c, connectErr = dialer.Dial(netType, s)
 
-		// pass in explicitly set SSH config using provided server name, but
-		// attempt to connect to specific IP Address returned from earlier
-		// lookup. We'll attempt to loop over each available IP Address until
-		// we are able to successfully connect to one of them.
-		// c, connectErr = client.DialWithDialerTLS(&dialer, s, tlsConfig)
-
 		if connectErr != nil {
 			logger.Debug().
 				Err(connectErr).

--- a/internal/rsat/rsat.go
+++ b/internal/rsat/rsat.go
@@ -79,8 +79,8 @@ type APIAuthInfo struct {
 	UserAgent string
 
 	// NetworkType indicates whether an attempt should be made to connect to
-	// only IPv4, only IPv6 or SSH servers listening on either of IPv4 or IPv6
-	// addresses ("auto").
+	// only IPv4, only IPv6 or Red Hat Satellite API endpoints listening on
+	// either of IPv4 or IPv6 addresses ("auto").
 	NetworkType string
 
 	// CACert is the optional certificate authority certificate used to


### PR DESCRIPTION
These references were left behind from the prototyping work originally performed to bootstrap this project.