### PR TITLE
Initial API query results paging support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,10 +108,7 @@ type Config struct {
 
 	// PerPageLimit overrides the default pagination limit for API calls. If
 	// not specified by the client the remote API uses a per-page default
-	// value of 20 results. Our goal is to have our default higher than this
-	// in order to support most Red Hat Satellite instances "out of the box".
-	//
-	// TODO: This will be less important once GH-245 is implemented.
+	// value of 20 results.
 	PerPageLimit int
 
 	// Log is an embedded zerolog Logger initialized via config.New().

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -27,7 +27,7 @@ const (
 	passwordFlagHelp               string = "The valid password for the specified user." //nolint:gosec
 	tcpPortFlagHelp                string = "The port used by the Red Hat Satellite server API."
 	networkTypeFlagHelp            string = "Limits network connections to one of tcp4 (IPv4-only), tcp6 (IPv6-only) or auto (either)."
-	perPageLimitFlagHelp           string = "Overrides the default pagination limit for API calls. Satellite API defaults to a per-page limit of 20 results, our default is higher."
+	perPageLimitFlagHelp           string = "Overrides the default pagination limit for API calls. Satellite API defaults to a per-page limit of 20 results."
 	caCertificateFlagHelp          string = "CA Certificate used to validate the certificate chain used by the Red Hat Satellite server."
 	permitTLSRenegotiationFlagHelp string = "Whether support for accepting renegotiation requests from the Red Hat Satellite server are permitted. This support is disabled by default. Renegotiation is not supported for TLS 1.3."
 	omitOKSyncPlansHelp            string = "Whether sync plans listed in plugin output should be limited to just those in a non-OK state."
@@ -109,14 +109,7 @@ const (
 	// defaultPerPageLimit is set higher than the default API pagination limit
 	// of 20 results per-page in an effort to support most Red Hat Satellite
 	// instances "out of the box".
-	//
-	// TODO: Having this value meet or exceed the number of organizations in a
-	// Red Hat Satellite instance will be less important once GH-245 is
-	// implemented and paging support is used. At that point we can reduce
-	// this number closer to the default API limit to reduce the risk of
-	// encountering API timeouts (e.g., for slower or more heavily loaded
-	// instances).
-	defaultPerPageLimit int = 50
+	defaultPerPageLimit int = 30
 
 	defaultInspectorOutputFormat string = InspectorOutputFormatPrettyTable
 )

--- a/internal/rsat/client.go
+++ b/internal/rsat/client.go
@@ -8,6 +8,7 @@
 package rsat
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
@@ -101,4 +102,47 @@ func NewAPIClient(apiAuthInfo APIAuthInfo, apiLimits APILimits, logger zerolog.L
 		Logger:   logger,
 		Limits:   apiLimits,
 	}
+}
+
+// submitAPIQueryRequest is a helper function used to submit a request to an
+// API endpoint and perform basic validation of the results.
+//
+// TODO: Refactor to be an APIClient method
+func submitAPIQueryRequest(
+	ctx context.Context,
+	client *APIClient,
+	apiURL string,
+	apiURLQueryParams map[string]string,
+	logger zerolog.Logger,
+) (*http.Response, error) {
+
+	logger.Debug().Msg("Preparing request for API query")
+	request, reqErr := prepareRequest(ctx, client, apiURL, apiURLQueryParams)
+	if reqErr != nil {
+		return nil, reqErr
+	}
+
+	logger.Debug().Msg("Submitting HTTP request")
+	response, respErr := client.Do(request)
+	if respErr != nil {
+		return nil, respErr
+	}
+	logger.Debug().Msg("Successfully submitted HTTP request")
+
+	// Make sure that we close the response body once we're done with it
+	defer func() {
+		if closeErr := response.Body.Close(); closeErr != nil {
+			logger.Error().Err(closeErr).Msg("error closing response body")
+		}
+	}()
+
+	// Evaluate the response
+	validateErr := validateResponse(ctx, response, logger, client.AuthInfo.ReadLimit)
+	if validateErr != nil {
+		return nil, validateErr
+	}
+
+	logger.Debug().Msg("Successfully validated HTTP response")
+
+	return response, nil
 }

--- a/internal/rsat/organizations.go
+++ b/internal/rsat/organizations.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/atc0005/go-nagios"
@@ -18,14 +19,33 @@ import (
 
 // OrganizationsResponse represents the API response from a request for all
 // organizations in the Red Hat Satellite server.
+//
+// https://access.redhat.com/documentation/en-us/red_hat_satellite/6.5/html-single/api_guide/index#sect-API_Guide-Understanding_the_JSON_Response_Format
+// https://access.redhat.com/documentation/en-us/red_hat_satellite/6.15/html-single/api_guide/index#sect-API_Guide-Understanding_the_JSON_Response_Format
 type OrganizationsResponse struct {
+	// Organizations is the collection of Organizations returned in the API
+	// query response.
 	Organizations []Organization `json:"results"`
-	Search        NullString     `json:"search"`
-	Sort          SortOptions    `json:"sort"`
-	Subtotal      int            `json:"subtotal"`
-	Total         int            `json:"total"`
-	Page          int            `json:"page"`
-	PerPage       int            `json:"per_page"`
+
+	// Search is the search string based on scoped_scoped syntax.
+	Search NullString `json:"search"`
+
+	// Sort is the optional sorting criteria for API query responses.
+	Sort SortOptions `json:"sort"`
+
+	// Subtotal is the number of objects returned with the given search
+	// parameters. If there is no search, then subtotal is equal to total.
+	Subtotal int `json:"subtotal"`
+
+	// Total is the total number of objects without any search parameters.
+	Total int `json:"total"`
+
+	// Page is the page number for the current query response results.
+	Page int `json:"page"`
+
+	// PerPage is the pagination limit applied to API query results. If not
+	// specified by the client this is the default value set by the API.
+	PerPage int `json:"per_page"`
 }
 
 // Organization is an isolated collection of systems, content, and other
@@ -64,57 +84,69 @@ func GetOrganizations(ctx context.Context, client *APIClient) ([]Organization, e
 		OrganizationsAPIEndPointURLTemplate,
 		client.AuthInfo.Server,
 		client.AuthInfo.Port,
-		client.Limits.PerPage,
 	)
 
-	request, err := prepareRequest(ctx, client, apiURL)
-	if err != nil {
-		return nil, err
-	}
+	allOrgs := make([]Organization, 0, client.Limits.PerPage*2)
 
-	logger.Debug().Msg("Submitting HTTP request")
+	apiURLQueryParams := make(map[string]string)
+	apiURLQueryParams[APIEndpointURLQueryParamFullResultKey] = APIEndpointURLQueryParamFullResultDefaultValue
+	apiURLQueryParams[APIEndpointURLQueryParamPerPageKey] = strconv.Itoa(client.Limits.PerPage)
 
-	response, respErr := client.Do(request)
-	if respErr != nil {
-		return nil, respErr
-	}
+	var nextPage int
+	for {
+		nextPage++
+		apiURLQueryParams[APIEndpointURLQueryParamPageKey] = strconv.Itoa(nextPage)
 
-	logger.Debug().Msg("Successfully submitted HTTP request")
-
-	// Make sure that we close the response body once we're done with it
-	defer func() {
-		if closeErr := response.Body.Close(); closeErr != nil {
-			logger.Error().Err(closeErr).Msgf("error closing response body")
+		response, respErr := submitAPIQueryRequest(ctx, client, apiURL, apiURLQueryParams, logger)
+		if respErr != nil {
+			return nil, respErr
 		}
-	}()
 
-	// Evaluate the response
-	validateErr := validateResponse(ctx, response, logger, client.AuthInfo.ReadLimit)
-	if validateErr != nil {
-		return nil, err
+		logger.Debug().Msgf(
+			"Decoding JSON data from %q using a limit of %d bytes",
+			apiURL,
+			client.AuthInfo.ReadLimit,
+		)
+
+		var orgsQueryResp OrganizationsResponse
+		decodeErr := decode(&orgsQueryResp, response.Body, logger, apiURL, client.AuthInfo.ReadLimit)
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+
+		logger.Debug().
+			Str("api_endpoint", apiURL).
+			Msg("Successfully decoded JSON data")
+
+		numNewOrgs := len(orgsQueryResp.Organizations)
+		numCollectedOrgs := len(allOrgs)
+		numOrgsRemaining := orgsQueryResp.Subtotal - numCollectedOrgs
+
+		logger.Debug().
+			Str("api_endpoint", apiURL).
+			Int("orgs_collected", numCollectedOrgs).
+			Int("orgs_new", numNewOrgs).
+			Msg("Added decoded organizations to collection")
+
+		logger.Debug().
+			Msg("Determining if we have collected all organizations from the API")
+
+		if numOrgsRemaining == 0 {
+			logger.Debug().
+				Msg("We have collected all organizations from the API")
+			break
+		}
+		logger.Debug().
+			Int("orgs_collected", numCollectedOrgs).
+			Int("orgs_remaining", numOrgsRemaining).
+			Msg("We have more organizations to collect from the API")
 	}
-
-	logger.Debug().Msgf(
-		"Decoding JSON data from %q using a limit of %d bytes",
-		apiURL,
-		client.AuthInfo.ReadLimit,
-	)
-
-	var orgsQueryResp OrganizationsResponse
-	decodeErr := decode(&orgsQueryResp, response.Body, logger, apiURL, client.AuthInfo.ReadLimit)
-	if decodeErr != nil {
-		return nil, decodeErr
-	}
-
-	logger.Debug().
-		Str("api_endpoint", apiURL).
-		Msg("Successfully decoded JSON data")
 
 	logger.Debug().
 		Str("runtime_total", time.Since(funcTimeStart).String()).
 		Msg("Completed retrieval of all organizations")
 
-	return orgsQueryResp.Organizations, nil
+	return allOrgs, nil
 }
 
 // Sort sorts the Organizations in the collection by name.

--- a/internal/rsat/rsat.go
+++ b/internal/rsat/rsat.go
@@ -26,22 +26,40 @@ const (
 	// OrganizationsAPIEndPointURLTemplate provides a template for a fully
 	// qualified API endpoint URL for retrieving Organizations from a Red Hat
 	// Satellite instance.
-	OrganizationsAPIEndPointURLTemplate string = "https://%s:%d/api/v2/organizations?full_result=1&per_page=%d"
+	// OrganizationsAPIEndPointURLTemplate string = "https://%s:%d/api/v2/organizations?full_result=1&per_page=%d&page=%d"
+	OrganizationsAPIEndPointURLTemplate string = "https://%s:%d/api/v2/organizations"
 
 	// SubscriptionsAPIEndPointURLTemplate provides a template for a fully
 	// qualified API endpoint URL for retrieving Subscriptions associated with
 	// a Red Hat Satellite Organization.
-	SubscriptionsAPIEndPointURLTemplate string = "https://%s:%d/katello/api/v2/organizations/%d/subscriptions?full_result=1&per_page=%d"
+	// SubscriptionsAPIEndPointURLTemplate string = "https://%s:%d/katello/api/v2/organizations/%d/subscriptions?full_result=1&per_page=%d&page=%d"
+	SubscriptionsAPIEndPointURLTemplate string = "https://%s:%d/katello/api/v2/organizations/%d/subscriptions"
 
 	// SyncPlansAPIEndPointURLTemplate provides a template for a fully
 	// qualified API endpoint URL for retrieving Sync Plans associated with a
 	// Red Hat Satellite Organization.
-	SyncPlansAPIEndPointURLTemplate string = "https://%s:%d/katello/api/v2/organizations/%d/sync_plans?full_result=1&per_page=%d"
+	// SyncPlansAPIEndPointURLTemplate string = "https://%s:%d/katello/api/v2/organizations/%d/sync_plans?full_result=1&per_page=%d&page=%d"
+	SyncPlansAPIEndPointURLTemplate string = "https://%s:%d/katello/api/v2/organizations/%d/sync_plans"
 
 	// ProductsAPIEndPointURLTemplate provides a template for a fully
 	// qualified API endpoint URL for retrieving Products associated with a
 	// Red Hat Satellite Organization.
-	ProductsAPIEndPointURLTemplate string = "https://%s:%d/katello/api/v2/products?organization_id=%d&full_result=1&per_page=%d"
+	// ProductsAPIEndPointURLTemplate string = "https://%s:%d/katello/api/v2/products?organization_id=%d&full_result=1&per_page=%d&page=%d"
+	ProductsAPIEndPointURLTemplate string = "https://%s:%d/katello/api/v2/products"
+)
+
+// Common/shared query parameter keys for Red Hat Satellite API endpoint URLs.
+const (
+	APIEndpointURLQueryParamOrganizationIDKey string = "organization_id"
+	APIEndpointURLQueryParamFullResultKey     string = "full_result"
+	APIEndpointURLQueryParamPerPageKey        string = "per_page"
+	APIEndpointURLQueryParamPageKey           string = "page"
+)
+
+// Red Hat Satellite API endpoint URL query parameter default values.
+const (
+	APIEndpointURLQueryParamFullResultDefaultValue string = "1"
+	APIEndpointURLQueryParamPageStartingValue      string = "1"
 )
 
 // Prep tasks for processing of Red Hat Satellite API endpoints.
@@ -52,6 +70,16 @@ const (
 	PrepTaskSubmitRequest    string = "submit request"
 	PrepTaskValidateResponse string = "validate response"
 )
+
+// APIURLQueryParams is the collection of key/value pairs required for queries
+// to API endpoints.
+//
+// TODO: Implement this to provide better validation of required query
+// parameters (e.g., enforce per_page presence).
+//
+// type APIURLQueryParams struct {
+// 	Values map[string]string
+// }
 
 // APIAuthInfo represents the settings needed to access Red Hat Satellite
 // server API endpoints.
@@ -97,8 +125,15 @@ type APIAuthInfo struct {
 }
 
 // SortOptions is the optional sorting criteria for API query responses.
+//
+// https://access.redhat.com/documentation/en-us/red_hat_satellite/6.5/html-single/api_guide/index#sect-API_Guide-Understanding_the_JSON_Response_Format
+// https://access.redhat.com/documentation/en-us/red_hat_satellite/6.15/html-single/api_guide/index#sect-API_Guide-Understanding_the_JSON_Response_Format
 type SortOptions struct {
-	By    NullString `json:"by"`
+	// By specifies by what field the API sorts the collection.
+	By NullString `json:"by"`
+
+	// Order is the sort order, either ASC for ascending or DESC for
+	// descending.
 	Order NullString `json:"order"`
 }
 
@@ -256,7 +291,7 @@ func validateResponse(ctx context.Context, response *http.Response, logger zerol
 
 // prepareRequest is a helper function that prepares a http.Request (including
 // all desired headers) for submission to an endpoint.
-func prepareRequest(ctx context.Context, client *APIClient, apiURL string) (*http.Request, error) {
+func prepareRequest(ctx context.Context, client *APIClient, apiURL string, apiURLQueryParams map[string]string) (*http.Request, error) {
 	if client == nil {
 		return nil, &PrepError{
 			Task:    PrepTaskPrepareRequest,
@@ -281,6 +316,24 @@ func prepareRequest(ctx context.Context, client *APIClient, apiURL string) (*htt
 		}
 	}
 
+	// We require at least the per_page setting.
+	//
+	// TODO: Move this into a separate Validate method for the
+	// APIURLQueryParams type so that we can apply multiple validations in one
+	// place (e.g., require per_page setting to be present, value values for
+	// it and other query parameters).
+	if len(apiURLQueryParams) < 1 {
+		return nil, &PrepError{
+			Task:    PrepTaskPrepareRequest,
+			Message: "error preparing HTTP request",
+			Source:  apiURL,
+			Cause: fmt.Errorf(
+				"required number of API URL query parameters were not provided: %w",
+				ErrMissingValue,
+			),
+		}
+	}
+
 	logger := client.Logger
 
 	logger.Debug().Msgf("Parsing %q as URL", apiURL)
@@ -294,6 +347,12 @@ func prepareRequest(ctx context.Context, client *APIClient, apiURL string) (*htt
 		}
 	}
 	logger.Debug().Msgf("Successfully parsed %q as URL", apiURL)
+
+	queryParams := parsedURL.Query()
+	for k, v := range apiURLQueryParams {
+		queryParams.Set(k, v)
+	}
+	parsedURL.RawQuery = queryParams.Encode()
 
 	logger.Debug().Msg("Preparing HTTP request")
 	request, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)


### PR DESCRIPTION
## Changes

- implement initial support for retrieving Organizations and Sync Plans via paging in place of a single larger request
- reduce our custom override for default `per_page` API results limit from `50` to `30` to compromise between a larger initial (single) request and using multiple requests with a smaller response set
- update API endpoint templates to drop fixed query parameters and rely on getter implementations to construct fully qualified endpoint URLs containing required query parameters and applicable values
- update doc comments coverage for `SyncPlanResponse` to describe the fields that we use from the API response
- update doc comments coverage for `OrganizationsResponse` to describe the fields that we use from the API response
- refactor `GetOrganizations` and `getOrgSyncPlans` functions to use a new `submitAPIQueryRequest` helper function to reduce code duplication

## References

- GH-245