### PR TITLE
Fix JSON decoding failure

### DIFF
--- a/internal/rsat/client.go
+++ b/internal/rsat/client.go
@@ -129,13 +129,6 @@ func submitAPIQueryRequest(
 	}
 	logger.Debug().Msg("Successfully submitted HTTP request")
 
-	// Make sure that we close the response body once we're done with it
-	defer func() {
-		if closeErr := response.Body.Close(); closeErr != nil {
-			logger.Error().Err(closeErr).Msg("error closing response body")
-		}
-	}()
-
 	// Evaluate the response
 	validateErr := validateResponse(ctx, response, logger, client.AuthInfo.ReadLimit)
 	if validateErr != nil {


### PR DESCRIPTION
Restore proper handling of response body closure by moving deferring closure to caller.

Resolve linter warnings by refactoring paging results iteration to use "are there more results" logic as part of the loop condition instead of using a separate check at the end of the loop.

Not completely convinced that this simplies the cognitive complexity angle; the previous logic (at least to me) is clearer.

refs GH-245