### PR TITLE
Fix paging collection logic

### DIFF
--- a/internal/rsat/organizations.go
+++ b/internal/rsat/organizations.go
@@ -9,6 +9,7 @@ package rsat
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -41,7 +42,12 @@ type OrganizationsResponse struct {
 	Total int `json:"total"`
 
 	// Page is the page number for the current query response results.
-	Page int `json:"page"`
+	//
+	// NOTE: In practice, this value has been found to be  returned as an
+	// integer in the first response and as a string value for each additional
+	// page of results. The json.Number type accepts either format when
+	// decoding the response.
+	Page json.Number `json:"page"`
 
 	// PerPage is the pagination limit applied to API query results. If not
 	// specified by the client this is the default value set by the API.
@@ -130,6 +136,8 @@ func GetOrganizations(ctx context.Context, client *APIClient) ([]Organization, e
 		if closeErr := response.Body.Close(); closeErr != nil {
 			logger.Error().Err(closeErr).Msg("error closing response body")
 		}
+
+		allOrgs = append(allOrgs, orgsQueryResp.Organizations...)
 
 		numNewOrgs := len(orgsQueryResp.Organizations)
 		numCollectedOrgs := len(allOrgs)

--- a/internal/rsat/syncplans.go
+++ b/internal/rsat/syncplans.go
@@ -9,6 +9,7 @@ package rsat
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -49,7 +50,12 @@ type SyncPlansResponse struct {
 	Total int `json:"total"`
 
 	// Page is the page number for the current query response results.
-	Page int `json:"page"`
+	//
+	// NOTE: In practice, this value has been found to be  returned as an
+	// integer in the first response and as a string value for each additional
+	// page of results. The json.Number type accepts either format when
+	// decoding the response.
+	Page json.Number `json:"page"`
 
 	// PerPage is the pagination limit applied to API query results. If not
 	// specified by the client this is the default value set by the API.
@@ -467,11 +473,11 @@ func getOrgSyncPlans(ctx context.Context, client *APIClient, org Organization) (
 			syncPlansQueryResp.SyncPlans[i].OrganizationTitle = org.Title
 		}
 
+		allSyncPlans = append(allSyncPlans, syncPlansQueryResp.SyncPlans...)
+
 		numNewSyncPlans := len(syncPlansQueryResp.SyncPlans)
 		numCollectedSyncPlans := len(allSyncPlans)
 		numSyncPlansRemaining := syncPlansQueryResp.Subtotal - numCollectedSyncPlans
-
-		allSyncPlans = append(allSyncPlans, syncPlansQueryResp.SyncPlans...)
 
 		subLogger.Debug().
 			Str("api_endpoint", apiURL).


### PR DESCRIPTION
- append collected Orgs/Plans *before* calculating remaining
- fix handling of inconsistent API query response for `page` property by using `json.Number` type for the `SyncPlansResponse` and and `OrganizationsResponse` types
  - on the first page of the API the `page` property has the value of `1` (an integer) whereas the property has the value `"2"` (a string) on the second page
  - light research indicates others have also encountered this for other (non-Red Hat) APIs
- use `io.TeeReader` when decoding the JSON payload in the response body *if* debug or trace logging levels are enabled
  - not technically needed, but proved very useful when debugging the unexpected type change behavior of the `page` property so I am opting to keep it for future debugging work

refs GH-245