### PR TITLE
Initial API query results paging support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,10 +108,7 @@ type Config struct {
 
 	// PerPageLimit overrides the default pagination limit for API calls. If
 	// not specified by the client the remote API uses a per-page default
-	// value of 20 results. Our goal is to have our default higher than this
-	// in order to support most Red Hat Satellite instances "out of the box".
-	//
-	// TODO: This will be less important once GH-245 is implemented.
+	// value of 20 results.
 	PerPageLimit int
 
 	// Log is an embedded zerolog Logger initialized via config.New().

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -27,7 +27,7 @@ const (
 	passwordFlagHelp               string = "The valid password for the specified user." //nolint:gosec
 	tcpPortFlagHelp                string = "The port used by the Red Hat Satellite server API."
 	networkTypeFlagHelp            string = "Limits network connections to one of tcp4 (IPv4-only), tcp6 (IPv6-only) or auto (either)."
-	perPageLimitFlagHelp           string = "Overrides the default pagination limit for API calls. Satellite API defaults to a per-page limit of 20 results, our default is higher."
+	perPageLimitFlagHelp           string = "Overrides the default pagination limit for API calls. Satellite API defaults to a per-page limit of 20 results."
 	caCertificateFlagHelp          string = "CA Certificate used to validate the certificate chain used by the Red Hat Satellite server."
 	permitTLSRenegotiationFlagHelp string = "Whether support for accepting renegotiation requests from the Red Hat Satellite server are permitted. This support is disabled by default. Renegotiation is not supported for TLS 1.3."
 	omitOKSyncPlansHelp            string = "Whether sync plans listed in plugin output should be limited to just those in a non-OK state."
@@ -109,14 +109,7 @@ const (
 	// defaultPerPageLimit is set higher than the default API pagination limit
 	// of 20 results per-page in an effort to support most Red Hat Satellite
 	// instances "out of the box".
-	//
-	// TODO: Having this value meet or exceed the number of organizations in a
-	// Red Hat Satellite instance will be less important once GH-245 is
-	// implemented and paging support is used. At that point we can reduce
-	// this number closer to the default API limit to reduce the risk of
-	// encountering API timeouts (e.g., for slower or more heavily loaded
-	// instances).
-	defaultPerPageLimit int = 50
+	defaultPerPageLimit int = 30
 
 	defaultInspectorOutputFormat string = InspectorOutputFormatPrettyTable
 )

--- a/internal/rsat/syncplans.go
+++ b/internal/rsat/syncplans.go
@@ -9,6 +9,7 @@ package rsat
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -25,15 +26,40 @@ const syncTimeGraceMinutes float64 = 5
 
 // SyncPlansResponse represents the API response from a request of all sync
 // plans for a specific organization.
+//
+// https://access.redhat.com/documentation/en-us/red_hat_satellite/6.5/html-single/api_guide/index#sect-API_Guide-Understanding_the_JSON_Response_Format
+// https://access.redhat.com/documentation/en-us/red_hat_satellite/6.15/html-single/api_guide/index#sect-API_Guide-Understanding_the_JSON_Response_Format
 type SyncPlansResponse struct {
-	Error     NullString  `json:"error"`
-	Search    NullString  `json:"search"`
-	SyncPlans SyncPlans   `json:"results"`
-	Sort      SortOptions `json:"sort"`
-	Subtotal  int         `json:"subtotal"`
-	Total     int         `json:"total"`
-	Page      int         `json:"page"`
-	PerPage   int         `json:"per_page"`
+	Error NullString `json:"error"`
+
+	// Search is the search string based on scoped_scoped syntax.
+	Search NullString `json:"search"`
+
+	// SyncPlans is the collection of Sync Plans returned in the API query
+	// response.
+	SyncPlans SyncPlans `json:"results"`
+
+	// Sort is the optional sorting criteria for API query responses.
+	Sort SortOptions `json:"sort"`
+
+	// Subtotal is the number of objects returned with the given search
+	// parameters. If there is no search, then subtotal is equal to total.
+	Subtotal int `json:"subtotal"`
+
+	// Total is the total number of objects without any search parameters.
+	Total int `json:"total"`
+
+	// Page is the page number for the current query response results.
+	//
+	// NOTE: In practice, this value has been found to be  returned as an
+	// integer in the first response and as a string value for each additional
+	// page of results. The json.Number type accepts either format when
+	// decoding the response.
+	Page json.Number `json:"page"`
+
+	// PerPage is the pagination limit applied to API query results. If not
+	// specified by the client this is the default value set by the API.
+	PerPage int `json:"per_page"`
 }
 
 // SyncPlan represents a Red Hat Satellite sync plan. Sync plans are used to
@@ -381,6 +407,8 @@ func (sps SyncPlans) Stuck() SyncPlans {
 
 // getOrgSyncPlans retrieves all sync plans for the given organization.
 func getOrgSyncPlans(ctx context.Context, client *APIClient, org Organization) (SyncPlans, error) {
+	funcTimeStart := time.Now()
+
 	subLogger := client.Logger.With().
 		Int("org_id", org.ID).
 		Str("org_name", org.Name).
@@ -391,60 +419,83 @@ func getOrgSyncPlans(ctx context.Context, client *APIClient, org Organization) (
 		client.AuthInfo.Server,
 		client.AuthInfo.Port,
 		org.ID,
-		client.Limits.PerPage,
 	)
 
-	subLogger.Debug().Msg("Preparing request to retrieve sync plans")
-	request, reqErr := prepareRequest(ctx, client, apiURL)
-	if reqErr != nil {
-		return nil, reqErr
-	}
+	allSyncPlans := make(SyncPlans, 0, client.Limits.PerPage*2)
 
-	subLogger.Debug().Msg("Submitting HTTP request")
-	response, respErr := client.Do(request)
-	if respErr != nil {
-		return nil, respErr
-	}
-	subLogger.Debug().Msg("Successfully submitted HTTP request")
+	apiURLQueryParams := make(map[string]string)
+	apiURLQueryParams[APIEndpointURLQueryParamFullResultKey] = APIEndpointURLQueryParamFullResultDefaultValue
+	apiURLQueryParams[APIEndpointURLQueryParamPerPageKey] = strconv.Itoa(client.Limits.PerPage)
 
-	// Make sure that we close the response body once we're done with it
-	defer func() {
+	var nextPage int
+	remainingSyncPlans := true
+
+	for remainingSyncPlans {
+		subLogger.Debug().
+			Msg("Collecting sync plans from the API")
+
+		nextPage++
+		apiURLQueryParams[APIEndpointURLQueryParamPageKey] = strconv.Itoa(nextPage)
+
+		response, respErr := submitAPIQueryRequest(ctx, client, apiURL, apiURLQueryParams, subLogger)
+		if respErr != nil {
+			return nil, respErr
+		}
+
+		subLogger.Debug().Msgf(
+			"Decoding JSON data from %q using a limit of %d bytes",
+			apiURL,
+			client.AuthInfo.ReadLimit,
+		)
+
+		var syncPlansQueryResp SyncPlansResponse
+		decodeErr := decode(&syncPlansQueryResp, response.Body, subLogger, apiURL, client.AuthInfo.ReadLimit)
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+
+		subLogger.Debug().
+			Str("api_endpoint", apiURL).
+			Msg("Successfully decoded JSON data")
+
+		// Close the response body once we're done with it. We explicitly
+		// close here vs deferring via closure to prevent accumulating client
+		// connections to the API if we need to perform multiple paged
+		// requests.
 		if closeErr := response.Body.Close(); closeErr != nil {
 			subLogger.Error().Err(closeErr).Msg("error closing response body")
 		}
-	}()
 
-	// Evaluate the response
-	validateErr := validateResponse(ctx, response, subLogger, client.AuthInfo.ReadLimit)
-	if validateErr != nil {
-		return nil, validateErr
-	}
+		// Annotate Sync Plans with specific Org values for convenience.
+		for i := range syncPlansQueryResp.SyncPlans {
+			syncPlansQueryResp.SyncPlans[i].OrganizationName = org.Name
+			syncPlansQueryResp.SyncPlans[i].OrganizationLabel = org.Label
+			syncPlansQueryResp.SyncPlans[i].OrganizationTitle = org.Title
+		}
 
-	subLogger.Debug().Msg("Successfully validated HTTP response")
+		allSyncPlans = append(allSyncPlans, syncPlansQueryResp.SyncPlans...)
 
-	subLogger.Debug().Msgf(
-		"Decoding JSON data from %q using a limit of %d bytes",
-		apiURL,
-		client.AuthInfo.ReadLimit,
-	)
+		numNewSyncPlans := len(syncPlansQueryResp.SyncPlans)
+		numCollectedSyncPlans := len(allSyncPlans)
+		numSyncPlansRemaining := syncPlansQueryResp.Subtotal - numCollectedSyncPlans
 
-	var syncPlansQueryResp SyncPlansResponse
-	decodeErr := decode(&syncPlansQueryResp, response.Body, subLogger, apiURL, client.AuthInfo.ReadLimit)
-	if decodeErr != nil {
-		return nil, decodeErr
-	}
+		subLogger.Debug().
+			Str("api_endpoint", apiURL).
+			Int("sync_plans_collected", numCollectedSyncPlans).
+			Int("sync_plans_new", numNewSyncPlans).
+			Int("sync_plans_remaining", numSyncPlansRemaining).
+			Msg("Added decoded sync plans to collection")
 
-	// Annotate Sync Plans with specific Org values for convenience.
-	for i := range syncPlansQueryResp.SyncPlans {
-		syncPlansQueryResp.SyncPlans[i].OrganizationName = org.Name
-		syncPlansQueryResp.SyncPlans[i].OrganizationLabel = org.Label
-		syncPlansQueryResp.SyncPlans[i].OrganizationTitle = org.Title
+		subLogger.Debug().
+			Msg("Determining if we have collected all sync plans from the API")
+
+		remainingSyncPlans = numSyncPlansRemaining != 0
 	}
 
 	subLogger.Debug().
-		Str("api_endpoint", apiURL).
-		Msg("Successfully decoded JSON data")
+		Str("runtime_total", time.Since(funcTimeStart).String()).
+		Msg("Completed retrieval of all sync plans for organization")
 
-	return syncPlansQueryResp.SyncPlans, nil
+	return allSyncPlans, nil
 
 }


### PR DESCRIPTION
## Changes

- implement initial support for retrieving Organizations and Sync Plans via paging in place of a single larger request
- reduce our custom override for default `per_page` API results limit from `50` to `30` to compromise between a larger initial (single) request and using multiple requests with a smaller response set
- update API endpoint templates to drop fixed query parameters and rely on getter implementations to construct fully qualified endpoint URLs containing required query parameters and applicable values
- update doc comments coverage for `SyncPlanResponse` to describe the fields that we use from the API response
- update doc comments coverage for `OrganizationsResponse` to describe the fields that we use from the API response
- refactor `GetOrganizations` and `getOrgSyncPlans` functions to use a new `submitAPIQueryRequest` helper function to reduce code duplication
- fix handling of inconsistent API query response for `page` property by using `json.Number` type for the `SyncPlansResponse` and and `OrganizationsResponse` types
  - on the first page of the API the `page` property has the value of `1` (an integer) whereas the property has the value `"2"` (a string) on the second page
  - light research indicates others have also encountered this for other (non-Red Hat) APIs
- use `io.TeeReader` when decoding the JSON payload in the response body *if* debug or trace logging levels are enabled
  - not technically needed, but proved very useful when debugging the unexpected type change behavior of the `page` property so I am opting to keep it for future debugging work

## References

- fixes GH-245
