### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/cmd/check_rsat_sync_plans/summary.go
+++ b/cmd/check_rsat_sync_plans/summary.go
@@ -50,7 +50,7 @@ func setLongServiceOutput(report string, _ rsat.Organizations, cfg *config.Confi
 
 	// If provided, put the report content first.
 	if report != "" {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&output,
 			"%s%s",
 			report,
@@ -59,9 +59,9 @@ func setLongServiceOutput(report string, _ rsat.Organizations, cfg *config.Confi
 	}
 
 	if cfg.ShowVerbose {
-		fmt.Fprintf(&output, "%s", nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(&output, "%s", nagios.CheckOutputEOL)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&output,
 			"%s------%s%s",
 			nagios.CheckOutputEOL,
@@ -69,49 +69,49 @@ func setLongServiceOutput(report string, _ rsat.Organizations, cfg *config.Confi
 			nagios.CheckOutputEOL,
 		)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&output,
 			"Configuration settings: %s%s",
 			nagios.CheckOutputEOL,
 			nagios.CheckOutputEOL,
 		)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&output,
 			"* Server: %v%s",
 			cfg.Server,
 			nagios.CheckOutputEOL,
 		)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&output,
 			"* Port: %v%s",
 			cfg.TCPPort,
 			nagios.CheckOutputEOL,
 		)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&output,
 			"* Username: %v%s",
 			cfg.Username,
 			nagios.CheckOutputEOL,
 		)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&output,
 			"* NetworkType: %v%s",
 			cfg.NetworkType,
 			nagios.CheckOutputEOL,
 		)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&output,
 			"* Timeout: %v%s",
 			cfg.Timeout(),
 			nagios.CheckOutputEOL,
 		)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&output,
 			"* UserAgent: %v%s",
 			cfg.UserAgent(),

--- a/cmd/lssp/reports.go
+++ b/cmd/lssp/reports.go
@@ -22,16 +22,16 @@ func generateReport(w io.Writer, orgs rsat.Organizations, cfg *config.Config, lo
 
 	switch cfg.InspectorOutputFormat {
 	case config.InspectorOutputFormatOverview:
-		fmt.Fprintln(w, reports.SyncPlansOverviewReport(orgs, cfg, logger))
+		_, _ = fmt.Fprintln(w, reports.SyncPlansOverviewReport(orgs, cfg, logger))
 
 	case config.InspectorOutputFormatSimpleTable:
-		fmt.Fprintln(w, reports.SyncPlansSimpleTableReport(orgs, cfg, logger))
+		_, _ = fmt.Fprintln(w, reports.SyncPlansSimpleTableReport(orgs, cfg, logger))
 
 	case config.InspectorOutputFormatPrettyTable:
-		fmt.Fprintln(w, reports.SyncPlansPrettyTableReport(orgs, cfg, logger))
+		_, _ = fmt.Fprintln(w, reports.SyncPlansPrettyTableReport(orgs, cfg, logger))
 
 	case config.InspectorOutputFormatVerbose:
-		fmt.Fprintln(w, reports.SyncPlansVerboseReport(orgs, cfg, logger))
+		_, _ = fmt.Fprintln(w, reports.SyncPlansVerboseReport(orgs, cfg, logger))
 	}
 
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,7 +172,7 @@ func Usage(flagSet *flag.FlagSet, w io.Writer) func() {
 	// Uninitialized flagset, provide stub usage information.
 	case flagSet == nil:
 		return func() {
-			fmt.Fprintln(w, "Failed to initialize configuration; nil FlagSet")
+			_, _ = fmt.Fprintln(w, "Failed to initialize configuration; nil FlagSet")
 		}
 
 	// Non-nil flagSet, proceed
@@ -182,8 +182,8 @@ func Usage(flagSet *flag.FlagSet, w io.Writer) func() {
 		flagSet.SetOutput(w)
 
 		return func() {
-			fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
-			fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+			_, _ = fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
+			_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 			flagSet.PrintDefaults()
 		}
 	}
@@ -201,7 +201,7 @@ func (c *Config) Help() string {
 	// Handle nil configuration initialization.
 	case c == nil || c.flagSet == nil:
 		// Fallback message noting the issue.
-		fmt.Fprintln(&helpTxt, ErrConfigNotInitialized)
+		_, _ = fmt.Fprintln(&helpTxt, ErrConfigNotInitialized)
 
 	default:
 		// Emit expected help output to builder.

--- a/internal/reports/overview.go
+++ b/internal/reports/overview.go
@@ -28,7 +28,7 @@ func SyncPlansOverviewReport(orgs rsat.Organizations, _ *config.Config, _ zerolo
 	orgs.Sort()
 
 	for _, org := range orgs {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&output,
 			"* %s (%d problems, %d enabled, %d disabled)%s",
 			org.Name,

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -15,7 +15,7 @@ import (
 )
 
 func addSyncPlansReportLeadIn(w io.Writer) {
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"%sSYNC PLANS OVERVIEW%s%s",
 		nagios.CheckOutputEOL,

--- a/internal/reports/simple-table.go
+++ b/internal/reports/simple-table.go
@@ -48,8 +48,8 @@ func simpleTableProblemStateToString(v interface{}) string {
 // syncPlansSimpleTableReport is a helper function that performs the bulk of
 // the "simple table" report output logic.
 func syncPlansSimpleTableReport(w io.Writer, cfg *config.Config, headerRow string, dataRowTmpl string, orgs rsat.Organizations) {
-	fmt.Fprintln(w, headerRow)
-	fmt.Fprintln(w, simpleTableHeaderSeparatorRow(headerRow, "\t"))
+	_, _ = fmt.Fprintln(w, headerRow)
+	_, _ = fmt.Fprintln(w, simpleTableHeaderSeparatorRow(headerRow, "\t"))
 
 	for i, org := range orgs {
 		for _, syncPlan := range org.SyncPlans {
@@ -58,7 +58,7 @@ func syncPlansSimpleTableReport(w io.Writer, cfg *config.Config, headerRow strin
 				continue
 
 			case orgs.NumProblemPlans() > 0:
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					w,
 					dataRowTmpl,
 					org.Name,
@@ -70,7 +70,7 @@ func syncPlansSimpleTableReport(w io.Writer, cfg *config.Config, headerRow strin
 				)
 
 			default:
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					w,
 					dataRowTmpl,
 					org.Name,
@@ -84,7 +84,7 @@ func syncPlansSimpleTableReport(w io.Writer, cfg *config.Config, headerRow strin
 
 		// Group sync plans visually based on Org.
 		if i+1 < len(orgs) {
-			fmt.Fprint(w, simpleTableDataSeparatorRow(headerRow, "\t"))
+			_, _ = fmt.Fprint(w, simpleTableDataSeparatorRow(headerRow, "\t"))
 		}
 	}
 }
@@ -103,8 +103,8 @@ func simpleTableHeaderSeparatorRow(headerRow string, headerRowSeparator string) 
 	}
 
 	for _, item := range headerTmplItems {
-		fmt.Fprint(&row, strings.Repeat("-", len(item)))
-		fmt.Fprint(&row, (headerRowSeparator))
+		_, _ = fmt.Fprint(&row, strings.Repeat("-", len(item)))
+		_, _ = fmt.Fprint(&row, (headerRowSeparator))
 	}
 
 	return row.String()
@@ -124,7 +124,7 @@ func SyncPlansSimpleTableReport(orgs rsat.Organizations, cfg *config.Config, log
 
 	// Add some lead-in spacing to better separate any earlier log messages from
 	// summary output
-	fmt.Fprintf(tw, "\n\n")
+	_, _ = fmt.Fprintf(tw, "\n\n")
 
 	orgs.Sort()
 
@@ -147,7 +147,7 @@ func SyncPlansSimpleTableReport(orgs rsat.Organizations, cfg *config.Config, log
 
 	syncPlansSimpleTableReport(tw, cfg, headerRow, dataRowTmpl, orgs)
 
-	fmt.Fprintln(tw)
+	_, _ = fmt.Fprintln(tw)
 
 	if err := tw.Flush(); err != nil {
 		logger.Error().Err(err).Msg("Error flushing tabwriter")

--- a/internal/reports/verbose.go
+++ b/internal/reports/verbose.go
@@ -45,7 +45,7 @@ func syncPlansVerboseReport(w io.Writer, cfg *config.Config, orgs rsat.Organizat
 		// list the Orgs here with summary details. We will skip listing the
 		// sync plans within each org.
 		case orgs.NumProblemPlans() > 0:
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"%s%s (%d stuck, %d enabled, %d disabled)%s",
 				nagios.CheckOutputEOL,
@@ -58,7 +58,7 @@ func syncPlansVerboseReport(w io.Writer, cfg *config.Config, orgs rsat.Organizat
 			continue
 
 		default:
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"* %s (%d enabled, %d disabled)%s",
 				org.Name,
@@ -80,7 +80,7 @@ func syncPlansVerboseReport(w io.Writer, cfg *config.Config, orgs rsat.Organizat
 			// are looking at isn't stuck (to contrast against any plans which
 			// are stuck).
 			case orgs.NumProblemPlans() > 0:
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					w,
 					"  * [Name: %s, Days Stuck: %s, Interval: %s, Next Sync: %s]%s",
 					syncPlan.Name,
@@ -91,7 +91,7 @@ func syncPlansVerboseReport(w io.Writer, cfg *config.Config, orgs rsat.Organizat
 				)
 
 			default:
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					w,
 					"  * [Name: %s, Interval: %s, Next Sync: %s]%s",
 					syncPlan.Name,
@@ -102,6 +102,6 @@ func syncPlansVerboseReport(w io.Writer, cfg *config.Config, orgs rsat.Organizat
 			}
 		}
 
-		fmt.Fprint(w, nagios.CheckOutputEOL)
+		_, _ = fmt.Fprint(w, nagios.CheckOutputEOL)
 	}
 }


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
